### PR TITLE
implementation of multiple layers for visualisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ python visualize_zarr.py </path/to/volume1.zarr /path/to/volume2.zarr ...> [--po
 
 ### Arguments
 
-* `file_path` (**required**) → Path to your `.zarr` directory(ies).
+* `file_path` (**required**) → Path to your `.zarr` directories.
 * `--host` → Host to bind server (default: `127.0.0.1`).
 * `--port` → Port for local server (default: `5000`).
 * `--name` → Custom layer names (default: `.zarr` basename).

--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ No additional packages are needed.
 ## Usage
 
 ```bash
-python visualize_zarr.py /path/to/volume.zarr [--port 5000] [--host 127.0.0.1] [--name mylayer]
+python visualize_zarr.py </path/to/volume1.zarr /path/to/volume2.zarr ...> [--port 5000] [--host 127.0.0.1] [--name <mylayer1 mylayer2 ...>]
 ```
 
 ### Arguments
 
-* `file_path` (**required**) → Path to your `.zarr` directory.
+* `file_path` (**required**) → Path to your `.zarr` directory(ies).
 * `--host` → Host to bind server (default: `127.0.0.1`).
 * `--port` → Port for local server (default: `5000`).
-* `--name` → Custom layer name (default: `.zarr` basename).
+* `--name` → Custom layer names (default: `.zarr` basename).
 * `--file_type` → File type prefix (default: `zarr`).
 * `--no-open` → Prevent auto-opening Neuroglancer in browser.
 

--- a/visualize_zarr.py
+++ b/visualize_zarr.py
@@ -10,8 +10,11 @@
 import argparse, json, os, threading, webbrowser
 from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
 from urllib.parse import quote
+import tempfile
 
 NEUROGLANCER_DEMO = "https://neuroglancer-demo.appspot.com/#!"
+
+running_servers = []
 
 class CORSRequestHandler(SimpleHTTPRequestHandler):
     # Serve files from a specific directory (passed via constructor)
@@ -31,51 +34,97 @@ class CORSRequestHandler(SimpleHTTPRequestHandler):
         self.send_header("Access-Control-Allow-Headers", "Range, Content-Type")
         self.end_headers()
 
+def is_port_in_use(host, port):
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex((host, port)) == 0
+    
 def start_server(root_dir, host, port):
     handler = lambda *a, **kw: CORSRequestHandler(*a, directory=root_dir, **kw)
     httpd = ThreadingHTTPServer((host, port), handler)
     t = threading.Thread(target=httpd.serve_forever, daemon=True)
     t.start()
+    running_servers.append(httpd)
     return httpd
 
-def build_state(file_http_url, layer_name,file_type='zarr'):
-    # Minimal/default state for a single image layer from a Zarr.
-    # Neuroglancer infers shape/chunks from Zarr metadata; voxel size defaults to 1x1x1.
-    return {
-        "layers": [
-            {
-                "type": "image",
-                "source": f"{file_type}://{file_http_url}",
-                "name": layer_name
-            }
-        ]
-        # You can add "crossSectionScale", "position", "layout", etc., if desired.
-    }
+def stop_all_servers():
+    for s in running_servers:
+        s.shutdown()
+        s.server_close()
+    running_servers.clear()
+
+def build_state(file_http_url, layer_name, file_type=['zarr']):
+    """
+    Build a Neuroglancer state with one or more layers.
+    Neuroglancer infers shape/chunks from Zarr metadata; voxel size defaults to 1x1x1.
+
+    Supports either single values or lists for each argument:
+      - file_http_url: str or list of str
+      - layer_name: str or list of str
+      - file_type: str or list of str (defaults to 'zarr' for all if single string)
+
+    Returns:
+        dict: A Neuroglancer state dictionary.
+    """
+
+    if len(file_type) < len(file_http_url):
+        if len(file_type) == 1:
+            file_type = file_type * len(file_http_url)
+        else:
+            raise SystemError(f"Unexpected number of file_types are defined: {file_type}")
+
+    layers = [
+        {
+            "type": "image",
+            "source": f"{ftype}://{url}",
+            "name": name
+        }
+        for url, name, ftype in zip(file_http_url, layer_name, file_type)
+    ]
+    # You can add "crossSectionScale", "position", "layout", etc., if desired.
+
+    return {"layers": layers}
 
 def main():
     ap = argparse.ArgumentParser(description="Open a local Zarr store in Neuroglancer Demo.")
-    ap.add_argument("file_path", help="Path to your .zarr directory")
+    ap.add_argument("file_path", nargs='+', help="Path to your .zarr directory")
     ap.add_argument("--host", default="127.0.0.1", help="Host to bind local HTTP server (default: 127.0.0.1)")
     ap.add_argument("--port", type=int, default=5000, help="Port for local HTTP server (default: 5000)")
-    ap.add_argument("--name", default=None, help="Layer name (default: basename of .zarr)")
+    ap.add_argument("--name", nargs='*', default=None, help="Layer name (default: basename of .zarr)")
     ap.add_argument("--file_type", default=None, help="file type (default: zarr)")
     ap.add_argument("--no-open", action="store_true", help="Do not auto-open the browser")
     args = ap.parse_args()
 
-    file_path = os.path.abspath(args.file_path.rstrip("/"))
-    if not os.path.isdir(file_path) or not file_path.endswith(".zarr"):
-        raise SystemExit("Please provide a path to a Zarr directory ending in .zarr")
+    file_paths = [os.path.abspath(fp.rstrip("/")) for fp in args.file_path]
+    for fp in file_paths:
+        if not os.path.isdir(fp) or not fp.endswith(".zarr"):
+            raise SystemExit(f"Please provide paths to Zarr directory(ies) ending in .zarr: {fp}")
 
-    root_dir = os.path.dirname(file_path)
-    base = os.path.basename(file_path)  # e.g., volume.zarr
-    layer_name = args.name or base
+    # Create symlinks of all input files into default root_dir
+    root_dir = tempfile.mkdtemp(prefix="zarr_server_")
+    for fp in file_paths:
+        base = os.path.basename(fp.rstrip("/"))
+        link_path = os.path.join(root_dir, base)
+        if os.path.lexists(link_path):
+            os.remove(link_path)
+        os.symlink(fp, link_path)
+
+    if args.name and len(args.name) != len(file_paths):
+        raise SystemExit("Number of --name arguments must match number of .zarr inputs.")
+    layer_names = args.name or [os.path.basename(fp) for fp in file_paths]
 
     # 1) Start a CORS-enabled server for the parent directory
-    httpd = start_server(root_dir, args.host, args.port)
+    if not is_port_in_use(args.host, args.port):
+        httpd = start_server(root_dir, args.host, args.port)
+    else:
+        raise SystemExit(f"Port '{args.port}' already in use; please select a different one.")
 
     # 2) Build Neuroglancer state pointing to the served Zarr
-    file_http_url = f"http://{args.host}:{args.port}/{base}/"
-    state = build_state(file_http_url, layer_name,file_type='zarr')
+    file_http_urls = [f"http://{args.host}:{args.port}/{os.path.basename(fp)}/" for fp in file_paths]
+    if args.file_type is not None:
+        state = build_state(file_http_urls, layer_names, file_type=args.file_type)
+    else:
+        state = build_state(file_http_urls, layer_names)
 
     # 3) Encode the state and construct the demo URL
     state_json = json.dumps(state, separators=(",", ":"))
@@ -93,6 +142,7 @@ def main():
     try:
         threading.Event().wait()  # sleep forever in main thread
     except KeyboardInterrupt:
+        stop_all_servers()
         pass
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Expanded implementation to allow multiple files and layer names to be defined as inputs of a single visualize_zarr call.
- Added error handling if port is already in use
- Added method to stop all running servers after program termination (needs further testing)